### PR TITLE
create votes table with associations to users and talks

### DIFF
--- a/lib/show_n_tell/talk.ex
+++ b/lib/show_n_tell/talk.ex
@@ -9,6 +9,9 @@ defmodule ShowNTell.Talk do
     field :estimated_duration, :integer
     field :title, :string
 
+    has_many :votes, ShowNTell.Vote
+
+
     timestamps()
   end
 

--- a/lib/show_n_tell/vote.ex
+++ b/lib/show_n_tell/vote.ex
@@ -1,0 +1,24 @@
+defmodule ShowNTell.Vote do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+
+  schema "votes" do
+
+    field :value, :integer
+
+    belongs_to :user, ShowNTell.Vote
+    belongs_to :talk, ShowNTell.Vote
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(vote, attrs) do
+    vote
+    |> cast(attrs, [:value, :user_id, :talk_id])
+    |> unique_constraint(:user, name: :votes_talk_user_id_index)
+    |> validate_required([:value, :user_id, :talk_id])
+  end
+end

--- a/priv/repo/migrations/20180412044053_create_votes.exs
+++ b/priv/repo/migrations/20180412044053_create_votes.exs
@@ -1,0 +1,18 @@
+defmodule ShowNTell.Repo.Migrations.CreateVotes do
+  use Ecto.Migration
+
+  def change do
+    create table(:votes, primary_key: false ) do
+      add :value, :integer
+      add :talk_id, references(:talks, on_delete: :nothing)
+      add :user_id, references(:users, on_delete: :nothing)
+
+      timestamps()
+    end
+
+    create unique_index(:votes, [:user_id, :talk_id], name: :votes_talk_user_id_index)
+
+    create index(:votes, [:talk_id])
+    create index(:votes, [:user_id])
+  end
+end


### PR DESCRIPTION
`create unique_index(:votes, [:user_id, :talk_id], name: :votes_talk_user_id_index)`
This line is intended to create a unique vote scoped to a user and a talk.  Ie: a user only has one vote per talk.  I am not entirely sure if this is the result.

I referenced: https://hexdocs.pm/ecto/Ecto.Changeset.html#unique_constraint/3
This was helpful also: http://rny.io/elixir/ecto/postgresql/2015/08/31/postgresql-indexing-with-ecto.html
