### PR TITLE
 #20: Make Github client id and client secret optional for test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,15 @@ env:
   global:
     - PSQL_USER=postgres
     - PSQL_DB=travis
+    - MIX_ENV=test
+
+script:
+  - mix do local.hex --force
+  - mix deps.get
+  - mix test
+  - mix credo
+
+cache:
+  directories:
+    - _build
+    - deps

--- a/config/config.exs
+++ b/config/config.exs
@@ -26,5 +26,5 @@ config :logger, :console,
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env}.exs"
 
-# Import application-specific config
+# Import application-specific config: optional params with good defaults.
 import_config "show_n_tell.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -44,3 +44,5 @@ config :show_n_tell, ShowNTell.Repo,
   database: "show_n_tell_dev",
   hostname: "localhost",
   pool_size: 10
+
+import_config "show_n_tell_required.exs"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -62,3 +62,4 @@ config :logger, level: :info
 # Finally import the config/prod.secret.exs
 # which should be versioned separately.
 import_config "prod.secret.exs"
+import_config "show_n_tell_required.exs"

--- a/config/show_n_tell.exs
+++ b/config/show_n_tell.exs
@@ -1,6 +1,4 @@
 use Mix.Config
 
 config :show_n_tell,
-  github_org: System.get_env("GITHUB_ORG") || "decisely",
-  github_client_id: (System.get_env("GITHUB_CLIENT_ID") || raise "must set environment variable GITHUB_CLIENT_ID"),
-  github_client_secret: (System.get_env("GITHUB_CLIENT_SECRET") || raise "must set environment variable GITHUB_CLIENT_SECRET")
+  github_org: System.get_env("GITHUB_ORG") || "decisely"

--- a/config/show_n_tell_required.exs
+++ b/config/show_n_tell_required.exs
@@ -1,0 +1,5 @@
+use Mix.Config
+
+config :show_n_tell,
+  github_client_id: (System.get_env("GITHUB_CLIENT_ID") || raise "must set environment variable GITHUB_CLIENT_ID"),
+  github_client_secret: (System.get_env("GITHUB_CLIENT_SECRET") || raise "must set environment variable GITHUB_CLIENT_SECRET")

--- a/config/test.exs
+++ b/config/test.exs
@@ -20,3 +20,8 @@ config :show_n_tell, ShowNTell.Repo,
 
 # Configure tesla for tests
 config :tesla, adapter: Tesla.Mock
+
+# Configure Show & Tell values for test: defaults.
+config :show_n_tell,
+  github_client_id: "test-client-id",
+  github_client_secret: "test-client-secret"

--- a/lib/show_n_tell/application.ex
+++ b/lib/show_n_tell/application.ex
@@ -1,4 +1,8 @@
 defmodule ShowNTell.Application do
+  @moduledoc """
+  Show N Tell application module documentation.
+  """
+  
   use Application
 
   # See https://hexdocs.pm/elixir/Application.html

--- a/lib/show_n_tell/talk.ex
+++ b/lib/show_n_tell/talk.ex
@@ -1,4 +1,8 @@
 defmodule ShowNTell.Talk do
+  @moduledoc """
+  Talk model documentation
+  """
+
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/lib/show_n_tell/user.ex
+++ b/lib/show_n_tell/user.ex
@@ -1,4 +1,8 @@
 defmodule ShowNTell.User do
+  @moduledoc """
+  User model documentation
+  """
+
   use Ecto.Schema
 
   import Ecto.Changeset

--- a/lib/show_n_tell/vote.ex
+++ b/lib/show_n_tell/vote.ex
@@ -1,4 +1,8 @@
 defmodule ShowNTell.Vote do
+  @moduledoc """
+  Vote model documentation
+  """
+
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule ShowNTell.Mixfile do
       {:postgrex, ">= 0.0.0"},
       {:gettext, "~> 0.11"},
       {:cowboy, "~> 1.0"},
-      {:tesla, "1.0.0-beta.1"},
+      {:tesla, "1.0.0"},
       {:jason, ">= 1.0.0"},
       {:credo, "~> 0.9.1", only: [:dev, :test], runtime: false},
       {:cors_plug, "~> 1.5"},

--- a/mix.lock
+++ b/mix.lock
@@ -15,7 +15,7 @@
   "idna": {:hex, :idna, "5.1.1", "cbc3b2fa1645113267cc59c760bafa64b2ea0334635ef06dbac8801e42f7279c", [:rebar3], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
   "jason": {:hex, :jason, "1.0.0", "0f7cfa9bdb23fed721ec05419bcee2b2c21a77e926bce0deda029b5adc716fe2", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
-  "mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [:mix], [], "hexpm"},
+  "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [:mix], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
   "oauth2": {:hex, :oauth2, "0.9.2", "db2f1c5a2c01a21f14a7527c3c31b87c9b156532d8a3761428bf6ff710b119b6", [:mix], [{:hackney, "~> 1.7", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.2.0", "2adfa4daf80c14dc36f522cf190eb5c4ee3e28008fc6394397c16f62a26258c2", [:rebar3], [], "hexpm"},
@@ -28,6 +28,6 @@
   "postgrex": {:hex, :postgrex, "0.13.5", "3d931aba29363e1443da167a4b12f06dcd171103c424de15e5f3fc2ba3e6d9c5", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm"},
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
-  "tesla": {:hex, :tesla, "1.0.0-beta.1", "5c1b5cccd20226f14720d38bd4ef07489d19798aa645e038df924c3d2a617d20", [:mix], [{:exjsx, ">= 3.0.0", [hex: :exjsx, repo: "hexpm", optional: true]}, {:fuse, "~> 2.4", [hex: :fuse, repo: "hexpm", optional: true]}, {:hackney, "~> 1.6", [hex: :hackney, repo: "hexpm", optional: true]}, {:ibrowse, "~> 4.4.0", [hex: :ibrowse, repo: "hexpm", optional: true]}, {:jason, ">= 1.0.0", [hex: :jason, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:poison, ">= 1.0.0", [hex: :poison, repo: "hexpm", optional: true]}], "hexpm"},
+  "tesla": {:hex, :tesla, "1.0.0", "94a9059456d51266f3d40b75ff6be3d18496072ce5ffaabad03d6c00f065cfd1", [:mix], [{:exjsx, ">= 3.0.0", [hex: :exjsx, repo: "hexpm", optional: true]}, {:fuse, "~> 2.4", [hex: :fuse, repo: "hexpm", optional: true]}, {:hackney, "~> 1.6", [hex: :hackney, repo: "hexpm", optional: true]}, {:ibrowse, "~> 4.4.0", [hex: :ibrowse, repo: "hexpm", optional: true]}, {:jason, ">= 1.0.0", [hex: :jason, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:poison, ">= 1.0.0", [hex: :poison, repo: "hexpm", optional: true]}], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
 }

--- a/test/show_n_tell/rest/github_api_test.exs
+++ b/test/show_n_tell/rest/github_api_test.exs
@@ -1,0 +1,48 @@
+defmodule ShowNTell.Rest.GithubApiTest do
+  use ExUnit.Case
+
+  import Tesla.Mock
+
+  alias ShowNTell.Rest.GithubApi
+
+  @client GithubApi.client("fake-token")
+  @user_url "https://api.github.com/user"
+  @user_emails_url "https://api.github.com/user/emails"
+  @user_orgs_url "https://api.github.com/user/orgs"
+
+  @user_body %{
+    "name" => "Mr Andrew Bator"
+  }
+
+  @user_emails_body [
+    %{"email" => "mr.bator@gmail.com", "primary" => false},
+    %{"email" => "andrew.bator@gmail.com", "primary" => true}
+  ]
+
+  @user_orgs_body [
+    %{"login" => "spacex"},
+    %{"login" => "decisely"}
+  ]
+
+  setup do
+    mock fn
+      %{method: :get, url: @user_url} -> %Tesla.Env{status: 200, body: @user_body} 
+      %{method: :get, url: @user_emails_url} -> %Tesla.Env{status: 200, body: @user_emails_body}
+      %{method: :get, url: @user_orgs_url} -> %Tesla.Env{status: 200, body: @user_orgs_body}
+    end
+
+    :ok
+  end
+
+  test "loads user name from github" do
+    assert {:ok, %Tesla.Env{body: @user_body}} = GithubApi.user(@client)
+  end
+
+  test "loads user emails from github" do
+    assert {:ok, %Tesla.Env{body: @user_emails_body}} = GithubApi.user_emails(@client)
+  end
+
+  test "loads user orgs from github" do
+    assert {:ok, %Tesla.Env{body: @user_orgs_body}} = GithubApi.user_orgs(@client)
+  end
+end


### PR DESCRIPTION
- Add missing tests for GithubApi module
- Remove other TODO from the code
- Add missing @moduledoc tags to fix `mix credo` warnings
- Improve Travis CI to cache dependencies and build

(This PR is wholesome, because it is lovingly made with Vim. Wink-wink, Denver)