### PR TITLE
#8: Add seeds for users and talks

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -55,7 +55,8 @@ defmodule ShowNTell.Mixfile do
   # See the documentation for `Mix` for more info on aliases.
   defp aliases do
     [
-      "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
+      "ecto.seed": ["run priv/repo/seeds.exs"],
+      "ecto.setup": ["ecto.create", "ecto.migrate", "ecto.seed"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       "test": ["ecto.create --quiet", "ecto.migrate", "test"]
     ]

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -9,3 +9,22 @@
 #
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
+
+alias ShowNTell.Repo
+alias ShowNTell.Talk
+alias ShowNTell.User
+
+%Talk{date: ~D[2018-07-01], title: "How to like your own code", description: "Best practices of writing code for humans", estimated_duration: 20}
+|> Repo.insert!
+
+%Talk{date: ~D[2018-07-01], title: "On yelling at your co-workers", description: "About some colorful language to be used while yelling", estimated_duration: 15}
+|> Repo.insert!
+
+%Talk{date: ~D[2018-07-08], title: "Work/Life balance", description: "No such thing", estimated_duration: 60}
+|> Repo.insert!
+
+%User{email: "mr.bator@gmail.com", first_name: "Andrew", last_name: "Bator", github_token: "123456789"}
+|> Repo.insert!
+
+%User{email: "uber.coder@gmail.com", first_name: "Denver", last_name: "Smith", github_token: "987654321"}
+|> Repo.insert!


### PR DESCRIPTION
This PR will need to be edited once https://github.com/denvaar/show-n-tell/pull/23 is merged in, to work properly on associations.

Also this PR adds this handy task to run seeds: `mix ecto.seed` - similar to Rails's `rails db:seed`.