### PR TITLE
#9: Add initial implementation of GraphQL for talks

### DIFF
--- a/lib/show_n_tell/talk.ex
+++ b/lib/show_n_tell/talk.ex
@@ -6,8 +6,11 @@ defmodule ShowNTell.Talk do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias ShowNTell.Repo
+  alias ShowNTell.Talk
+
   schema "talks" do
-    field :date, :date
+    field :talk_date, :date
     field :description, :string
     field :estimated_duration, :integer
     field :title, :string
@@ -21,7 +24,17 @@ defmodule ShowNTell.Talk do
   @doc false
   def changeset(talk, attrs) do
     talk
-    |> cast(attrs, [:title, :description, :estimated_duration, :date])
-    |> validate_required([:title, :description, :estimated_duration, :date])
+    |> cast(attrs, [:title, :description, :estimated_duration, :talk_date])
+    |> validate_required([:title, :description, :estimated_duration, :talk_date])
+  end
+
+  def list_talks() do
+    Repo.all(Talk)
+  end
+
+  def create_talk(args) do
+    %Talk{}
+    |> changeset(args)
+    |> Repo.insert
   end
 end

--- a/lib/show_n_tell_web/router.ex
+++ b/lib/show_n_tell_web/router.ex
@@ -10,4 +10,11 @@ defmodule ShowNTellWeb.Router do
 
     post "/authenticate", AuthController, :create
   end
+
+  scope "/" do
+    pipe_through :api
+
+    forward "/graphiql", Absinthe.Plug.GraphiQL,
+      schema: ShowNTellWeb.Schema
+  end
 end

--- a/lib/show_n_tell_web/schema.ex
+++ b/lib/show_n_tell_web/schema.ex
@@ -1,0 +1,41 @@
+defmodule ShowNTellWeb.Schema do
+  @moduledoc """
+  GraphQL schema
+  """
+  use Absinthe.Schema
+
+  import_types Absinthe.Type.Custom
+
+  alias ShowNTellWeb.TalksResolver
+
+  object :talk do
+    field :id, non_null(:id)
+    field :title, non_null(:string)
+    field :description, non_null(:string)
+    field :estimated_duration, non_null(:integer)
+    field :talk_date, non_null(:date)
+  end
+
+  query do
+    field :talk, :talk do
+      arg :id, non_null(:id)
+      resolve &TalksResolver.talk/3
+    end
+
+    field :talks, non_null(list_of(non_null(:talk))) do
+      arg :limit, :integer
+      resolve &TalksResolver.talks/3
+    end
+  end
+
+  mutation do
+    field :create_talk, :talk do
+      arg :title, non_null(:string)
+      arg :description, non_null(:string)
+      arg :estimated_duration, non_null(:integer)
+      arg :talk_date, non_null(:date)
+
+      resolve &TalksResolver.create_talk/3
+    end
+  end
+end

--- a/lib/show_n_tell_web/talks_resolver.ex
+++ b/lib/show_n_tell_web/talks_resolver.ex
@@ -1,0 +1,26 @@
+defmodule ShowNTellWeb.TalksResolver do
+  @moduledoc """
+  This module is used from Absinthen GraphQL schema
+  to resolve DB queries and mutations.
+  """
+
+  alias ShowNTell.Repo
+  alias ShowNTell.Talk
+
+  def talk(_root, args, _info) do
+    {:ok, Repo.get(Talk, args[:id])}
+  end
+
+  def talks(_root, _args, _info) do
+    talks = Talk.list_talks()
+
+    {:ok, talks}
+  end
+
+  def create_talk(_root, args, _info) do
+    case Talk.create_talk(args) do
+      {:ok, talk} -> {:ok, talk}
+      _error -> {:error, "could not create talk"}
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,9 @@ defmodule ShowNTell.Mixfile do
       {:jason, ">= 1.0.0"},
       {:credo, "~> 0.9.1", only: [:dev, :test], runtime: false},
       {:cors_plug, "~> 1.5"},
-      {:dotenv, "~> 2.0.0"}
+      {:dotenv, "~> 2.0.0"},
+      {:absinthe_ecto, "~> 0.1.0"},
+      {:absinthe_plug, "~> 1.4.0"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,7 @@
 %{
+  "absinthe": {:hex, :absinthe, "1.4.12", "50e7a70088e5896fe3581958f36f6b6bd9e6f36b9626d85db42f1283bbdd5d86", [:mix], [{:dataloader, "~> 1.0.0", [hex: :dataloader, repo: "hexpm", optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "absinthe_ecto": {:hex, :absinthe_ecto, "0.1.3", "420b68129e79fe4571a4838904ba03e282330d335da47729ad52ffd7b8c5fcb1", [:mix], [{:absinthe, "~> 1.3.0 or ~> 1.4.0", [hex: :absinthe, repo: "hexpm", optional: false]}, {:ecto, ">= 0.0.0", [hex: :ecto, repo: "hexpm", optional: false]}], "hexpm"},
+  "absinthe_plug": {:hex, :absinthe_plug, "1.4.4", "f93db43554ee75ab5d23a7757f27cf3edc8b240d8b6f8f7f2764578ac502a8d6", [:mix], [{:absinthe, "~> 1.4.11", [hex: :absinthe, repo: "hexpm", optional: false]}, {:plug, "~> 1.3.2 or ~> 1.4", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.3.1", "d0f424232390bf47d82da8478022301c561cf6445b5b5fb6a84d49a9e76d2639", [:rebar3], [{:parse_trans, "3.2.0", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},

--- a/priv/repo/migrations/20180622194223_rename_date_on_talks.exs
+++ b/priv/repo/migrations/20180622194223_rename_date_on_talks.exs
@@ -1,0 +1,7 @@
+defmodule ShowNTell.Repo.Migrations.RenameDateOnTalks do
+  use Ecto.Migration
+
+  def change do
+    rename table(:talks), :date, to: :talk_date
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -19,11 +19,11 @@ andrew = %User{email: "mr.bator@gmail.com", first_name: "Andrew", last_name: "Ba
 denver = %User{email: "uber.coder@gmail.com", first_name: "Denver", last_name: "Smith", github_token: "987654321"}
          |> Repo.insert!
 
-Ecto.build_assoc(andrew, :talks, %{date: ~D[2018-07-01], title: "How to like your own code", description: "Best practices of writing code for humans", estimated_duration: 20})
+Ecto.build_assoc(andrew, :talks, %{talk_date: ~D[2018-07-01], title: "How to like your own code", description: "Best practices of writing code for humans", estimated_duration: 20})
 |> Repo.insert!
 
-Ecto.build_assoc(andrew, :talks, %{date: ~D[2018-07-01], title: "On yelling at your co-workers", description: "About some colorful language to be used while yelling", estimated_duration: 15})
+Ecto.build_assoc(andrew, :talks, %{talk_date: ~D[2018-07-01], title: "On yelling at your co-workers", description: "About some colorful language to be used while yelling", estimated_duration: 15})
 |> Repo.insert!
 
-Ecto.build_assoc(denver, :talks, %{date: ~D[2018-07-08], title: "Work/Life balance", description: "No such thing", estimated_duration: 60})
+Ecto.build_assoc(denver, :talks, %{talk_date: ~D[2018-07-08], title: "Work/Life balance", description: "No such thing", estimated_duration: 60})
 |> Repo.insert!

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -52,7 +52,7 @@ CREATE TABLE public.talks (
     title character varying(255),
     description character varying(255),
     estimated_duration integer,
-    date date,
+    talk_date date,
     inserted_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     speaker_id bigint
@@ -212,5 +212,5 @@ ALTER TABLE ONLY public.votes
 -- PostgreSQL database dump complete
 --
 
-INSERT INTO public."schema_migrations" (version) VALUES (20180404032432), (20180411205345), (20180412044053), (20180617204953);
+INSERT INTO public."schema_migrations" (version) VALUES (20180404032432), (20180411205345), (20180412044053), (20180617204953), (20180622194223);
 

--- a/test/show_n_tell/rest/github_api_test.exs
+++ b/test/show_n_tell/rest/github_api_test.exs
@@ -1,5 +1,5 @@
 defmodule ShowNTell.Rest.GithubApiTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   import Tesla.Mock
 

--- a/test/show_n_tell/rest/github_auth_test.exs
+++ b/test/show_n_tell/rest/github_auth_test.exs
@@ -1,5 +1,5 @@
 defmodule ShowNTell.Rest.GithubAuthTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   import Tesla.Mock
 

--- a/test/show_n_tell_web/talk_resolver_test.exs
+++ b/test/show_n_tell_web/talk_resolver_test.exs
@@ -1,0 +1,31 @@
+defmodule ShowNTellWeb.TalksResolverTest do
+  use ShowNTellWeb.ConnCase
+
+  alias ShowNTell.Talk
+  alias ShowNTellWeb.TalksResolver
+  
+  @talk %{
+    title: "Goodness in programming",
+    description: "How goodness helps programming",
+    estimated_duration: 59,
+    talk_date: ~D[2018-07-01]
+  }
+
+  describe "talk/3" do
+    test "loads one talk by id" do
+      {:ok, talk} = Talk.create_talk(@talk)
+      assert TalksResolver.talk(nil, %{id: talk.id}, nil) == {:ok, talk}
+    end
+
+    test "returns nil of talk doesn't exist" do
+      assert TalksResolver.talk(nil, %{id: -1}, nil) == {:ok, nil}
+    end
+  end
+
+  describe "talks/3" do
+    test "returns all found talks" do
+      {:ok, talk} = Talk.create_talk(@talk)
+      assert TalksResolver.talks(nil, nil, nil) == {:ok, [talk]}
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,3 @@
 ExUnit.start()
 
 Ecto.Adapters.SQL.Sandbox.mode(ShowNTell.Repo, :manual)
-


### PR DESCRIPTION
This is the initial implementation of GraphQL for talks.

The following queries/mutations are supported:

1. `talks` - lists all talks.
1. `talk(id: n)` - load one talk by id.
1. `create_talk { params }` - create one talk.

I also created tests for `TalksResolver`.

**BTW:** I renamed `talks.date` to `talks.talk_date` - a bit redundant, but means fewer errors/issues in SQL queries and code. `date` is a special keyword in databases and code.